### PR TITLE
Specify the need for using SINATRA_ENV=development when running rake tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,10 @@ end
 Now, run the migration from the terminal with `rake db:migrate`.
 
 ```bash
-rake db:migrate
+rake db:migrate SINATRA_ENV=development
 ```
+
+Why add `SINATRA_ENV=development`, you might ask? Well, remember the top line of `config/environment.rb`? It's telling Sinatra that it should use the "development" environment for both `shotgun` and the testing suite. Therefore, we want to make sure our migrations run on the same environment as well, and specifying `SINATRA_ENV=development` allows us to do that. 
 
 You should see the following output:
 


### PR DESCRIPTION
As a response to #12 
Would definitely take input on the wording or content here, but I consider this high priority. Students run into a plethora of issues with both knowing to use `SINATRA_ENV` and later `RAILS_ENV` so I think it's best we communicate it upfront. 